### PR TITLE
Added DisableVerify option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ The library verifies that the time difference between generation of the signatur
     http.Handle("/foo", hs.Verify(h, getValue))
 
 
+#### Testing
+
+    key := []byte("does not matter")
+    hs := httpsign.New(key)
+    hs.DisableVerify = true
+
+Adding the Verify() middleware can make it really annoying to test a local service.  You can optionally set
+`DisableVerify` to `true` in order to simplify the Verify() handler such that it looks for the signature header but
+does not validate its value.
+
+
 ### Contributing
 
     git clone git@github.com:RobotsAndPencils/go-httpsign.git

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ The library verifies that the time difference between generation of the signatur
     hs.DisableVerify = true
 
 Adding the Verify() middleware can make it really annoying to test a local service.  You can optionally set
-`DisableVerify` to `true` in order to simplify the Verify() handler such that it looks for the signature header but
-does not validate its value.
+`DisableVerify` to `true` in order to simplify the Verify() handler such that it always determines the request is valid,
+regardless wether the signaturate header is valid or even present.
 
 
 ### Contributing

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The library verifies that the time difference between generation of the signatur
 
 Adding the Verify() middleware can make it really annoying to test a local service.  You can optionally set
 `DisableVerify` to `true` in order to simplify the Verify() handler such that it always determines the request is valid,
-regardless wether the signaturate header is valid or even present.
+regardless whether the signaturate header is valid or even present.
 
 
 ### Contributing

--- a/httpsign.go
+++ b/httpsign.go
@@ -61,11 +61,7 @@ func (hs *HttpSign) Verify(h http.Handler, v GetValue) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		header := r.Header.Get(hs.HeaderName)
 		if hs.DisableVerify {
-			if header == "" {
-				hs.writeInvalid(w)
-			} else {
-				h.ServeHTTP(w, r)
-			}
+			h.ServeHTTP(w, r)
 			return
 		}
 		expectedSignature, expectedEpoch, err := parseHeader(header)

--- a/httpsign_test.go
+++ b/httpsign_test.go
@@ -154,18 +154,10 @@ func TestVerifyWhenDisabled(t *testing.T) {
 	resp, err := http.DefaultClient.Do(req)
 	assert.Nil(err)
 	defer resp.Body.Close()
-	assert.Equal(http.StatusBadRequest, resp.StatusCode)
-
-	header := hs.GenerateHeaderValue(value)
-	req, err = http.NewRequest("GET", ts.URL, nil)
-	assert.Nil(err)
-	req.Header.Set(hs.HeaderName, header)
-	resp, err = http.DefaultClient.Do(req)
-	assert.Nil(err)
-	defer resp.Body.Close()
 	assert.Equal(http.StatusOK, resp.StatusCode)
 
-	header = hs.GenerateHeaderValue("some random value")
+	// make request with a bad header
+	header := hs.GenerateHeaderValue("some random value")
 	req, err = http.NewRequest("GET", ts.URL, nil)
 	assert.Nil(err)
 	req.Header.Set(hs.HeaderName, header)

--- a/httpsign_test.go
+++ b/httpsign_test.go
@@ -128,7 +128,51 @@ func TestVerify(t *testing.T) {
 	assert.Nil(err)
 	defer resp.Body.Close()
 	assert.Equal(http.StatusOK, resp.StatusCode)
+}
 
+func TestVerifyWhenDisabled(t *testing.T) {
+	assert := assert.New(t)
+	value := randomString(25)
+	key := []byte(randomString(100))
+	hs := New(key)
+	hs.DisableVerify = true
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	v := func(w http.ResponseWriter, r *http.Request) string {
+		return value
+	}
+
+	ts := httptest.NewServer(hs.Verify(h, v))
+	defer ts.Close()
+
+	// make request with no header
+	req, err := http.NewRequest("GET", ts.URL, nil)
+	assert.Nil(err)
+	resp, err := http.DefaultClient.Do(req)
+	assert.Nil(err)
+	defer resp.Body.Close()
+	assert.Equal(http.StatusBadRequest, resp.StatusCode)
+
+	header := hs.GenerateHeaderValue(value)
+	req, err = http.NewRequest("GET", ts.URL, nil)
+	assert.Nil(err)
+	req.Header.Set(hs.HeaderName, header)
+	resp, err = http.DefaultClient.Do(req)
+	assert.Nil(err)
+	defer resp.Body.Close()
+	assert.Equal(http.StatusOK, resp.StatusCode)
+
+	header = hs.GenerateHeaderValue("some random value")
+	req, err = http.NewRequest("GET", ts.URL, nil)
+	assert.Nil(err)
+	req.Header.Set(hs.HeaderName, header)
+	resp, err = http.DefaultClient.Do(req)
+	assert.Nil(err)
+	defer resp.Body.Close()
+	assert.Equal(http.StatusOK, resp.StatusCode)
 }
 
 func randomString(size int) string {


### PR DESCRIPTION
#### What's this PR do?

Adds a DisableVerify option that hamstrings the Verify() middleware handler.  When true, this option causes the Verify() check to require a non-empty header value but does not actually care about the contents of the value.

#### Where should the reviewer start?

See change set.

#### Any background context you want to provide?

This will help test services locally without having the dynamically configure the middleware handlers chain.

#### Does the change have adequate test coverage?

See unit tests.