### PR TITLE
Add request as arg to log hook for better log messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ The library verifies that the time difference between generation of the signatur
     hs.SecondsAllowance = 10    // to set to 10 seconds
 
 You can specify a "log hook" function that gets called whenever a failure happens in the Verify() handler.  This helps
-debugging deployments when keys and clocks do not match up.
+debugging deployments when keys and clocks do not match up.  The request is passed to the handler so that information
+can be pulled from it to form a more helpful log message.
 
-    hs.LookHook = func(msg string) {
+    hs.LookHook = func(r *http.Request, msg string) {
         log.Printf("HTTPSIGN ERROR: %s\n", msg)
     }
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can specify a "log hook" function that gets called whenever a failure happen
 debugging deployments when keys and clocks do not match up.  The request is passed to the handler so that information
 can be pulled from it to form a more helpful log message.
 
-    hs.LookHook = func(r *http.Request, msg string) {
+    hs.LogHook = func(r *http.Request, msg string) {
         log.Printf("HTTPSIGN ERROR: %s\n", msg)
     }
 

--- a/httpsign_test.go
+++ b/httpsign_test.go
@@ -173,7 +173,7 @@ func TestVerifyLogs(t *testing.T) {
 	key := []byte(randomString(100))
 	hs := New(key)
 	var lastLogMsg string
-	hs.LogHook = func(msg string) {
+	hs.LogHook = func(r *http.Request, msg string) {
 		lastLogMsg = msg
 	}
 


### PR DESCRIPTION
#### What's this PR do?

Adds the request as an argument to the LogHook function.
#### Where should the reviewer start?

Change set
#### How should this be manually tested?

`make test`
#### Any background context you want to provide?

The intended use case is for acquiring context from the request in order to craft better log messages.
#### Does the change have adequate test coverage ?

Uses pre-existing tests.
